### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.1.1

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -15,25 +15,25 @@
   • macOS: update viewport size if it changed while another docker tab was active
   • Windows: don't lose focus when Tab is pressed
 @provides
-  [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/$version/$path
-  [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/$version/$path
-  [darwin-arm64] reaper_imgui-arm64.dylib https://github.com/cfillion/reaimgui/releases/download/$version/$path
-  [linux32] reaper_imgui-i686.so https://github.com/cfillion/reaimgui/releases/download/$version/$path
-  [linux64] reaper_imgui-x86_64.so https://github.com/cfillion/reaimgui/releases/download/$version/$path
-  [linux-armv7l] reaper_imgui-armv7l.so https://github.com/cfillion/reaimgui/releases/download/$version/$path
-  [linux-aarch64] reaper_imgui-aarch64.so https://github.com/cfillion/reaimgui/releases/download/$version/$path
-  [win32] reaper_imgui-x86.dll https://github.com/cfillion/reaimgui/releases/download/$version/$path
-  [win64] reaper_imgui-x64.dll https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [darwin-arm64] reaper_imgui-arm64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [linux32] reaper_imgui-i686.so https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [linux64] reaper_imgui-x86_64.so https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [linux-armv7l] reaper_imgui-armv7l.so https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [linux-aarch64] reaper_imgui-aarch64.so https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [win32] reaper_imgui-x86.dll https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [win64] reaper_imgui-x64.dll https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [script main] reaper_imgui/ReaImGui_Demo.lua
   [script main] reaper_imgui/ReaImGui_Hello World.eel
   [script main] reaper_imgui/ReaImGui_Hello World (legacy syntax).eel
 @link
   cfillion.ca https://cfillion.ca
+  Forum thread https://forum.cockos.com/showthread.php?t=250419
   GitHub repository https://github.com/cfillion/reaimgui
   Issue tracker https://github.com/cfillion/reaimgui/issues
   dearimgui.org https://www.dearimgui.org/
   Dear ImGui FAQ https://www.dearimgui.org/faq
-  Forum thread https://forum.cockos.com/showthread.php?t=250419
 @screenshot https://i.imgur.com/SQpGdWi.png
 @donation
   Donate via PayPal https://paypal.me/cfillion

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -49,4 +49,3 @@
   ## Contributing
 
   Send bug reports on the [issue tracker](https://github.com/cfillion/reaimgui/issues). The source code is provided under LGPLv3 on [GitHub](https://github.com/cfillion/reaimgui). Patches can be submitted as pull requests.
-

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,24 +1,39 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.1
+@version 0.1.1
+@changelog
+  • Add EEL2 example using the legacy < 5.24 syntax [#1]
+  • Fix first frame having twice the contents in the example scripts
+  • macOS: process the first click over an unfocused window
+  • Remove focus from ImGui input controls when the context window itself loses focus
+
+  Docking bugfixes:
+  • Fix keyboard input going to REAPER when docked
+  • Skip rendering when docked and another docker tab is active
+  • Linux & Windows: fix mousewheel events leaking to REAPER
+  • Linux: fix crashes, flickering and incomplete rendering
+  • macOS: update viewport size if it changed while another docker tab was active
+  • Windows: don't lose focus when Tab is pressed
 @provides
-  [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
-  [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
-  [darwin-arm64] reaper_imgui-arm64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
-  [linux32] reaper_imgui-i686.so https://github.com/cfillion/reaimgui/releases/download/v$version/$path
-  [linux64] reaper_imgui-x86_64.so https://github.com/cfillion/reaimgui/releases/download/v$version/$path
-  [linux-armv7l] reaper_imgui-armv7l.so https://github.com/cfillion/reaimgui/releases/download/v$version/$path
-  [linux-aarch64] reaper_imgui-aarch64.so https://github.com/cfillion/reaimgui/releases/download/v$version/$path
-  [win32] reaper_imgui-x86.dll https://github.com/cfillion/reaimgui/releases/download/v$version/$path
-  [win64] reaper_imgui-x64.dll https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [darwin-arm64] reaper_imgui-arm64.dylib https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [linux32] reaper_imgui-i686.so https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [linux64] reaper_imgui-x86_64.so https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [linux-armv7l] reaper_imgui-armv7l.so https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [linux-aarch64] reaper_imgui-aarch64.so https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [win32] reaper_imgui-x86.dll https://github.com/cfillion/reaimgui/releases/download/$version/$path
+  [win64] reaper_imgui-x64.dll https://github.com/cfillion/reaimgui/releases/download/$version/$path
   [script main] reaper_imgui/ReaImGui_Demo.lua
   [script main] reaper_imgui/ReaImGui_Hello World.eel
+  [script main] reaper_imgui/ReaImGui_Hello World (legacy syntax).eel
 @link
   cfillion.ca https://cfillion.ca
   GitHub repository https://github.com/cfillion/reaimgui
   Issue tracker https://github.com/cfillion/reaimgui/issues
   dearimgui.org https://www.dearimgui.org/
   Dear ImGui FAQ https://www.dearimgui.org/faq
+  Forum thread https://forum.cockos.com/showthread.php?t=250419
 @screenshot https://i.imgur.com/SQpGdWi.png
 @donation
   Donate via PayPal https://paypal.me/cfillion
@@ -34,3 +49,4 @@
   ## Contributing
 
   Send bug reports on the [issue tracker](https://github.com/cfillion/reaimgui/issues). The source code is provided under LGPLv3 on [GitHub](https://github.com/cfillion/reaimgui). Patches can be submitted as pull requests.
+

--- a/API/reaper_imgui/ReaImGui_Demo.lua
+++ b/API/reaper_imgui/ReaImGui_Demo.lua
@@ -7348,4 +7348,4 @@ end
 --     r.ImGui_End();
 -- }
 
-demo.loop()
+reaper.defer(demo.loop)

--- a/API/reaper_imgui/ReaImGui_Hello World (legacy syntax).eel
+++ b/API/reaper_imgui/ReaImGui_Hello World (legacy syntax).eel
@@ -1,0 +1,48 @@
+// @noindex
+
+// For compatibility with REAPER versions prior 6.24.
+// See hello_world.eel (ReaImGui_Hello World.eel) for an example using the new extension API syntax.
+
+FLT_MIN = 0.0001; // 1.17549e-38
+
+color = 0;
+#notes = "";
+
+ctx = extension_api("ImGui_CreateContext", "Hello World!", 500, 420);
+
+function update() (
+  track = GetSelectedTrack(0, 0);
+
+  !track ? (
+    color = 0;
+    #notes = "";
+  );
+
+  extension_api("ImGui_SetNextWindowPos", ctx, 0, 0);
+  extension_api("ImGui_GetDisplaySize", ctx, w, h);
+  extension_api("ImGui_SetNextWindowSize", ctx, w, h);
+  extension_api("ImGui_Begin", ctx, "main", 0, extension_api("ImGui_WindowFlags_NoDecoration")) ? (
+    extension_api("ImGui_TextWrapped", ctx, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ultrices turpis lectus, in semper ligula blandit in. Duis non ipsum varius, pretium magna eu, mattis sapien. Maecenas augue mi, luctus sed leo et, ullamcorper convallis ligula. Nunc vitae porttitor quam. Integer a lorem fermentum, dapibus tortor ut, gravida erat. Quisque ut justo ante. Quisque fringilla a lectus a porta.");
+    extension_api("ImGui_Spacing", ctx);
+
+    color = GetTrackColor(track);
+    extension_api("ImGui_ColorEdit3", ctx, "track color", color) ?
+      SetTrackColor(track, color);
+    extension_api("ImGui_Spacing", ctx);
+
+    GetSetMediaTrackInfo_String(track, "P_EXT:imhw_notes", #notes, 0);
+    extension_api("ImGui_InputTextMultiline", ctx, "track notes", #notes, 0, -FLT_MIN) ?
+      GetSetMediaTrackInfo_String(track, "P_EXT:imhw_notes", #notes, 1);
+  );
+  extension_api("ImGui_End", ctx);
+);
+
+function loop() (
+  extension_api("ImGui_IsCloseRequested", ctx) ?
+    extension_api("ImGui_DestroyContext", ctx) : (
+    update();
+    defer("loop()");
+  )
+);
+
+defer("loop()");

--- a/API/reaper_imgui/ReaImGui_Hello World.eel
+++ b/API/reaper_imgui/ReaImGui_Hello World.eel
@@ -44,4 +44,4 @@ function loop() (
   )
 );
 
-loop();
+defer("loop()");


### PR DESCRIPTION
• Add EEL2 example using the legacy < 5.24 syntax [#1]
• Fix first frame having twice the contents in the example scripts
• macOS: process the first click over an unfocused window
• Remove focus from ImGui input controls when the context window itself loses focus

Docking bugfixes:
• Fix keyboard input going to REAPER when docked
• Skip rendering when docked and another docker tab is active
• Linux & Windows: fix mousewheel events leaking to REAPER
• Linux: fix crashes, flickering and incomplete rendering
• macOS: update viewport size if it changed while another docker tab was active
• Windows: don't lose focus when Tab is pressed