### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.5.6

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,17 +1,16 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.5.5
+@version 0.5.6
 @changelog
-  • Demo: disable docking combo box when docking is unavailable
-  • macOS: fix topmost state being reset when REAPER regains focus
-  • Update Dear ImGui to v1.84.1 (release notes at https://github.com/ocornut/imgui/releases/tag/v1.84)
+  • Demo: rename the 'Top most' checkbox to 'Always on top'
+  • Documentation: add ImGui_Font* to the list of ValidatePtr's supported types
+  • Documentation: fix the main content area not filling the browser window's full width
+  • Documentation: revert marking p_open arguments as non-optional
+  • Windows: disable topmost when the REAPER app is inactive
+  • Windows: fix topmost being reset when REAPER is unminimized [p=2476936]
 
   API changes:
-  • Add BeginDisabled/EndDisabled and StyleVar_DisabledAlpha
-  • Add DetachFont
-  • Add TableColumnFlags_Disabled and TableColumnFlags_NoHeaderLabel
-  • Add WindowFlags_TopMost [p=2468716][p=2471188][p=2476740]
-  • Remove ColorEditFlags__OptionsDefault
+  • Add the text filter API [p=2476922]
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path


### PR DESCRIPTION
• Demo: rename the 'Top most' checkbox to 'Always on top'
• Documentation: add ImGui_Font* to the list of ValidatePtr's supported types
• Documentation: fix the main content area not filling the browser window's full width
• Documentation: revert marking p_open arguments as non-optional
• Windows: disable topmost when the REAPER app is inactive
• Windows: fix topmost being reset when REAPER is unminimized [p=2476936]

API changes:
• Add the text filter API [p=2476922]