### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.5.9

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -6,7 +6,7 @@
   • Docker: obey WindowFlags_NoFocusOnAppearing if set on any hosted windows
   • Fix the main viewport having a zero position and size [p=2498028]
   • Fix WindowFlags_NoFocusOnAppearing not having an effect within the first 3 frames
-  • Update to Dear ImGui v1.85
+  • Update to Dear ImGui v1.85 <https://github.com/ocornut/imgui/releases/tag/v1.85>
   
   API changes:
   • Add DockHierarchy and NoPopupHierarchy in both FocusedFlags and HoveredFlags

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -2,7 +2,7 @@
 @author cfillion
 @version 0.5.9
 @changelog
-  • Docker: fix docked windows not being drawn on macOS if opened within the first 3 frames of the context's life
+  • Docker: fix windows not being drawn on macOS within the first 3 frames or if WindowFlags_NoFocusOnAppearing is set
   • Fix the main viewport having a zero position and size [p=2498028]
   • Update to Dear ImGui v1.85
 

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -3,6 +3,7 @@
 @version 0.5.9
 @changelog
   • Docker: fix docked windows not being drawn on macOS if opened within the first 3 frames of the context's life
+  • Fix the main viewport having a zero position and size [p=2498028]
   • Update to Dear ImGui v1.85
 
   API changes:

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -7,7 +7,7 @@
   • Update to Dear ImGui v1.85
 
   API changes:
-  • Add DockHierarchy NoPopupHierarchy in both FocusedFlags and HoveredFlags
+  • Add DockHierarchy and NoPopupHierarchy in both FocusedFlags and HoveredFlags
   • Add ShowStackToolWindow (also Demo->Tools->Stack Tool)
   • Remove GetWindowContentRegionWidth
 @provides

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -2,10 +2,12 @@
 @author cfillion
 @version 0.5.9
 @changelog
-  • Docker: fix windows not being drawn on macOS within the first 3 frames or if WindowFlags_NoFocusOnAppearing is set
+  • Docker: fix no rendering on macOS if opened within the first 3 frames of the context
+  • Docker: obey WindowFlags_NoFocusOnAppearing if set on any hosted windows
   • Fix the main viewport having a zero position and size [p=2498028]
+  • Fix WindowFlags_NoFocusOnAppearing not having an effect within the first 3 frames
   • Update to Dear ImGui v1.85
-
+  
   API changes:
   • Add DockHierarchy and NoPopupHierarchy in both FocusedFlags and HoveredFlags
   • Add ShowStackToolWindow (also Demo->Tools->Stack Tool)

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,9 +1,14 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.5.8
+@version 0.5.9
 @changelog
-  • Font: downgrade FreeType to 2.10.4 as workaround for a crash in 2.11.0 on Windows [p=2486019][p=2486079]
-  • Linux: fix window visibility when dragging them over REAPER's main window [p=2486034]
+  • Docker: fix docked windows not being drawn on macOS if opened within the first 3 frames of the context's life
+  • Update to Dear ImGui v1.85
+
+  API changes:
+  • Add DockHierarchy NoPopupHierarchy in both FocusedFlags and HoveredFlags
+  • Add ShowStackToolWindow (also Demo->Tools->Stack Tool)
+  • Remove GetWindowContentRegionWidth
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path


### PR DESCRIPTION
• Docker: fix no rendering on macOS if opened within the first 3 frames of the context
• Docker: obey WindowFlags_NoFocusOnAppearing if set on any hosted windows
• Fix the main viewport having a zero position and size [p=2498028]
• Fix WindowFlags_NoFocusOnAppearing not having an effect within the first 3 frames
• Update to Dear ImGui v1.85

API changes:
• Add DockHierarchy and NoPopupHierarchy in both FocusedFlags and HoveredFlags
• Add ShowStackToolWindow (also Demo->Tools->Stack Tool)
• Remove GetWindowContentRegionWidth