### PR TITLE
Release ReaBlink: Ableton Link REAPER plug-in extension v0.4.4

### DIFF
--- a/API/ak5k_ReaBlink.ext
+++ b/API/ak5k_ReaBlink.ext
@@ -1,19 +1,24 @@
 @description ReaBlink: Ableton Link REAPER plug-in extension
 @author ak5k
-@version 0.4.3
+@version 0.4.4
+@changelog
+  Puppet mode related performance tweaks.
+  ReaBlink Monitor script file now has commented out placeholder line for enabling Master mode.
 @provides
-  [win64] reaper_reablink-x64.dll https://github.com/ak5k/reablink/releases/download/v$version/reaper_reablink-x64.dll
-  [script main] ReaBlink_Monitor.lua https://github.com/ak5k/reablink/releases/download/v$version/ReaBlink_Monitor.lua
-  [win32] reaper_reablink-x86.dll https://github.com/ak5k/reablink/releases/download/v$version/reaper_reablink-x86.dll
-  [darwin64] reaper_reablink-arm64-x86_64.dylib https://github.com/ak5k/reablink/releases/download/v$version/reaper_reablink-arm64-x86_64.dylib
-  [darwin-arm64] reaper_reablink-arm64-x86_64.dylib https://github.com/ak5k/reablink/releases/download/v$version/reaper_reablink-arm64-x86_64.dylib
-  [linux32] reaper_reablink-i686.so https://github.com/ak5k/reablink/releases/download/v$version/reaper_reablink-i686.so
-  [linux64] reaper_reablink-x86_64.so https://github.com/ak5k/reablink/releases/download/v$version/reaper_reablink-x86_64.so
-  [linux-armv7l] reaper_reablink-armv7l.so https://github.com/ak5k/reablink/releases/download/v$version/reaper_reablink-armv7l.so
-  [linux-aarch64] reaper_reablink-aarch64.so https://github.com/ak5k/reablink/releases/download/v$version/reaper_reablink-aarch64.so
+  [win64] reaper_reablink-x64.dll https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [script main] ReaBlink_Monitor.lua https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [win32] reaper_reablink-x86.dll https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [linux32] reaper_reablink-i686.so https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [linux64] reaper_reablink-x86_64.so https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [linux-armv7l] reaper_reablink-armv7l.so https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [linux-aarch64] reaper_reablink-aarch64.so https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [darwin-arm64] reaper_reablink-arm64.dylib https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [darwin64] reaper_reablink-x86_64.dylib https://github.com/ak5k/reablink/releases/download/v$version/$path
+  [darwin32] reaper_reablink-i386.dylib https://github.com/ak5k/reablink/releases/download/v$version/$path
 @screenshot https://i.imgur.com/Q8PZUIk.gif
 @about
   REAPER Plug-In Extension providing ReaScript bindings for Ableton Link session, and Ableton Link Test Plan compliant implementations (Master/Puppet modes) for REAPER. 
 
   [Quick start user guide](https://github.com/ak5k/reablink/wiki/Quick-start-user-guide)\
   [More information](https://forum.cockos.com/showthread.php?t=254027)
+


### PR DESCRIPTION
Puppet mode related performance tweaks.
ReaBlink Monitor script file now has commented out placeholder line for enabling Master mode.