### PR TITLE
reapack.com_upload_1593897605124 - Update resource links

### DIFF
--- a/Control Surfaces/brumbear_ReaKontrol.ext
+++ b/Control Surfaces/brumbear_ReaKontrol.ext
@@ -5,8 +5,10 @@
   - added CUSTOM ACTIONS functionality
   - user editable configuration file
 @provides
-  reaper_kontrol.dll https://stash.reaper.fm/39829/reaper_kontrol.dll
+  [win64] reaper_kontrol.dll https://stash.reaper.fm/39829/reaper_kontrol.dll
   ReaKontrolConfig/reakontrol.ini https://stash.reaper.fm/39830/reakontrol.ini
+  [darwin64] reaper_kontrol.dylib https://stash.reaper.fm/38633/reaper_kontrol.dylib
 @link https://github.com/brummbrum/reaKontrol/releases
 @screenshot https://raw.githubusercontent.com/brummbrum/reaKontrol/Releases/ReaKontrol_v100.png
 @about https://github.com/brummbrum/reaKontrol/blob/Releases/ReaKontrol_v100_Manual.pdf
+

--- a/Control Surfaces/brumbear_ReaKontrol.ext
+++ b/Control Surfaces/brumbear_ReaKontrol.ext
@@ -5,8 +5,8 @@
   - added CUSTOM ACTIONS functionality
   - user editable configuration file
 @provides
-  [win64] reaper_kontrol.dll https://stash.reaper.fm/39829/reaper_kontrol.dll
-  ReaKontrolConfig/reakontrol.ini https://stash.reaper.fm/39830/reakontrol.ini
+  [win64] reaper_kontrol.dll https://github.com/brummbrum/reaKontrol/releases/download/v1.00/reaper_kontrol.dll
+  ReaKontrolConfig/reakontrol.ini https://github.com/brummbrum/reaKontrol/releases/download/v1.00/reakontrol.ini
   [darwin64] reaper_kontrol.dylib https://stash.reaper.fm/38633/reaper_kontrol.dylib
 @link https://github.com/brummbrum/reaKontrol/releases
 @screenshot https://raw.githubusercontent.com/brummbrum/reaKontrol/Releases/ReaKontrol_v100.png


### PR DESCRIPTION
updating the resource links for the older release v1.00 from Stash to Github to allow proper downgrading.

Not sure if this is the correct way of changing an older release. Since this relates to an old release I was trying to create a pull request to the original upload branch from Github rather than using the ReaPack website's package editor. However, it seems I can only merge to master, not the old branch. Hope I am not creating a mess. But as you can see the change is pretty obvious. Let me know if you want me to rather use the website even when addressing an old release. Anyway, this should not be necessary anymore in the future - I will take care to use unique download URL per version (i.e. directly from Github). Thx!