### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.7

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,17 +1,32 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.6.2
+@version 0.7
 @changelog
-  • Fix a crash when destroying list clippers while a different context is active
-  • Fix empty points array crashing DrawList_Add{Polyline,ConvexPolyFilled}
-  • Linux: restore broken key up/down events when an IME is active
-  • macOS: allow OpenGL software renderering for wider compatibility
-  • macOS: fix keyboard input when holding down a mouse button and the "Allow keyboard commands when mouse-editing" setting is disabled [p=2552296]
-  • Windows: receive Alt key events when "Prevent ALT key from focusing main menu" is enabled
+  • Add backward-compatibility script imgui.lua
+  • Fix broken mouse inputs after destroying a window while a mouse button is down
+  • Implement window transparency (requires REAPER v6.55+ on Linux)
+  • Increase maximum object allocation limit to 1000
+  • Linux: harden v0.6's improved mouse and keyboard input (now requires REAPER v6.57+)
+  • Optimize object pointer validation (about 2x faster)
+  • Patch dear imgui to enable background alpha and corner rounding for top-level windows
+  • Update dear imgui to v1.88 <https://github.com/ocornut/imgui/releases/tag/v1.88>
 
   API changes:
-  • DrawList_PathArcTo: fix incorrect default value for 'num_segments' when omitted
-  • Revert "Fix DrawList_AddTextEx not using the default bitmap font when font == nil" from v0.6
+  • Add ColorConvert{Double4ToU32,U32ToDouble4}
+  • Add DebugTextEncoding
+  • Add GetWindowViewport
+  • Add HoveredFlags_NoNavOverride
+  • Add ShowDebugLogWindow
+  • Combo and ListBox: use null bytes for delimiting items as in vanilla dear imgui (now requires REAPER 6.44+ in Lua and EEL, t=261079)
+  • Distinguish between empty and nil optional strings in Lua on REAPER 6.58+ [t=266405]
+  • Expose additional context settings via {Get,Set}ConfigVar
+  • Nerf ColorConvert{RGBtoHSV,HSVtoRGB}'s packed integer return value and optional alpha argument [t=266396]
+  • Python: unexpose output-only values from the argument list
+  • Python: unexpose unsafe buffer size arguments
+  • Rename CaptureKeyboardFromApp to SetNextFrameWantCaptureKeyboard
+  • Rename KeyModFlags_* constants to ModFlags_*
+  • Reorder GetVersion's return values and add IMGUI_VERSION_NUM
+  • Replace {Get,Set}ConfigFlags with {Get,Set}ConfigVar(ConfigVar_Flags)
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
@@ -27,6 +42,7 @@
   [script main] ReaImGui_Hello World (legacy syntax).eel https://github.com/cfillion/reaimgui/raw/v$version/examples/hello_world_legacy.eel
   [script] imgui_python.py https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [data] reaper_imgui_doc.html https://github.com/cfillion/reaimgui/releases/download/v$version/$path
+  [script] imgui.lua https://github.com/cfillion/reaimgui/releases/download/v$version/$path
 @link
   cfillion.ca https://cfillion.ca
   Forum thread https://forum.cockos.com/showthread.php?t=250419


### PR DESCRIPTION
• Add backward-compatibility script imgui.lua
• Fix broken mouse inputs after destroying a window while a mouse button is down
• Implement window transparency (requires REAPER v6.55+ on Linux)
• Increase maximum object allocation limit to 1000
• Linux: harden v0.6's improved mouse and keyboard input (now requires REAPER v6.57+)
• Optimize object pointer validation (about 2x faster)
• Patch dear imgui to enable background alpha and corner rounding for top-level windows
• Update dear imgui to v1.88 <https://github.com/ocornut/imgui/releases/tag/v1.88>

API changes:
• Add ColorConvert{Double4ToU32,U32ToDouble4}
• Add DebugTextEncoding
• Add GetWindowViewport
• Add HoveredFlags_NoNavOverride
• Add ShowDebugLogWindow
• Combo and ListBox: use null bytes for delimiting items as in vanilla dear imgui (now requires REAPER 6.44+ in Lua and EEL, t=261079)
• Distinguish between empty and nil optional strings in Lua on REAPER 6.58+ [t=266405]
• Expose additional context settings via {Get,Set}ConfigVar
• Nerf ColorConvert{RGBtoHSV,HSVtoRGB}'s packed integer return value and optional alpha argument [t=266396]
• Python: unexpose output-only values from the argument list
• Python: unexpose unsafe buffer size arguments
• Rename CaptureKeyboardFromApp to SetNextFrameWantCaptureKeyboard
• Rename KeyModFlags_* constants to ModFlags_*
• Reorder GetVersion's return values and add IMGUI_VERSION_NUM
• Replace {Get,Set}ConfigFlags with {Get,Set}ConfigVar(ConfigVar_Flags)