### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.7.2

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -5,7 +5,8 @@
   • Fix window under the window under mouse getting hovered for 1 frame on mouse release
   • macOS: fix crash when the context is destroyed while a window is docked
   • macOS: fix framebuffer size not updating when switching from another docker tab
-  • macOS: fix noninitial windows not gaining focus on open
+  • macOS: fix non-initial windows not gaining focus on open
+  • Windows: fix multiple DPI scaling issues
 
   API changes:
   • Add GetWindowDpiScale
@@ -14,7 +15,7 @@
   • Add GFX2IMGUI_NO_BLIT_PREMULTIPLY option [p=2609372]
   • Fix nearest font selection when sizes smaller than requested are loaded [p=2609372]
   • Keep alive fonts while they're actively being drawn from a blitted buffer [p=2609372]
-  • Warn when subtituting font for the default one
+  • Warn when substituting font for the default one
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -3,7 +3,7 @@
 @version 0.7.2
 @changelog
   • Fix window under the window under mouse getting hovered for 1 frame on mouse release
-  • macOS: fix crash when the context is destroyed while a window is docked
+  • macOS: fix a crash when the context is destroyed while a window is docked
   • macOS: fix framebuffer size not updating when switching from another docker tab
   • macOS: fix non-initial windows not gaining focus on open
   • Windows: fix multiple DPI scaling issues

--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,19 +1,20 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.7.1
+@version 0.7.2
 @changelog
-  • Add a translation layer for running gfx scripts on ReaImGui (gfx2imgui.lua)
-  • Enable SetNextWindowBgAlpha for all windows
-  • Fix corrupted font texture in contexts having windows using different DPI scaling
-  • Fix assertion failure after attaching fonts when more than one DPI scale is used
-  • Fix potential crash on exit in REAPER < 6.67 due to plugin registration keys being invalidated [reapack#56]
-  • macOS: fix pressed keyboard keys getting stuck when opening modal dialogs
-  • macOS: fix rescaling when moving windows to a monitor using a different DPI setting
-  • macOS: fix windows not moving above the menu bar on macOS 12 [p=2579183]
-  • macOS: gain keyboard focus when switching from another docker tab
+  • Fix window under the window under mouse getting hovered for 1 frame on mouse release
+  • macOS: fix crash when the context is destroyed while a window is docked
+  • macOS: fix framebuffer size not updating when switching from another docker tab
+  • macOS: fix noninitial windows not gaining focus on open
 
   API changes:
-  • Add the DrawListSplitter API
+  • Add GetWindowDpiScale
+
+  gfx2imgui:
+  • Add GFX2IMGUI_NO_BLIT_PREMULTIPLY option [p=2609372]
+  • Fix nearest font selection when sizes smaller than requested are loaded [p=2609372]
+  • Keep alive fonts while they're actively being drawn from a blitted buffer [p=2609372]
+  • Warn when subtituting font for the default one
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path


### PR DESCRIPTION
• Fix window under the window under mouse getting hovered for 1 frame on mouse release
• macOS: fix crash when the context is destroyed while a window is docked
• macOS: fix framebuffer size not updating when switching from another docker tab
• macOS: fix noninitial windows not gaining focus on open

API changes:
• Add GetWindowDpiScale

gfx2imgui:
• Add GFX2IMGUI_NO_BLIT_PREMULTIPLY option [p=2609372]
• Fix nearest font selection when sizes smaller than requested are loaded [p=2609372]
• Keep alive fonts while they're actively being drawn from a blitted buffer [p=2609372]
• Warn when subtituting font for the default one