### PR TITLE
Release ReaLlm: REAPER Low latency monitoring plug-in extension v0.4.0

### DIFF
--- a/FX/ak5k_ReaLlm REAPER Low latency monitoring plug-in extension.ext
+++ b/FX/ak5k_ReaLlm REAPER Low latency monitoring plug-in extension.ext
@@ -1,9 +1,10 @@
 @description ReaLlm: REAPER Low latency monitoring plug-in extension
 @author ak5k
-@version 0.3.2
+@version 0.4.0
 @changelog
-  Apple ARM64 related memory bug fix, maybe other systems too.
-  Dropped highly experimental and optional PDC mode check feature for now.
+  REAPER v6.72 or later required.
+  Disables PDC for monitored signalchain to achieve lower latencies or to allow more processing while monitoring.
+  "P_PDCLIMIT" can be set as floating point number, e.g. "0.5" to set target latency of 0.5 times current buffer/block size.
 @provides
   [linux-aarch64] reaper_reallm-aarch64.so https://github.com/ak5k/reallm/releases/download/v$version/$path
   [darwin-arm64] reaper_reallm-arm64.dylib https://github.com/ak5k/reallm/releases/download/v$version/$path


### PR DESCRIPTION
REAPER v6.72 or later required.
Disables PDC for monitored signalchain to achieve lower latencies or to allow more processing while monitoring.
"P_PDCLIMIT" can be set as floating point number, e.g. "0.5" to set target latency of 0.5 times current buffer/block size.