### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.8.6

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,33 +1,19 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.8.5
+@version 0.8.6
 @changelog
-  • Add a new API for running EEL programs
-  • Collect all errors in a single report window
-  • Disable ConfigVar_InputTrickleEventQueue by default
-  • Fix duplicate error reports when failing to end a frame
-  • Remove global object count limit (limit context attachments instead)
-  • Update to dear imgui v1.89.4 <https://github.com/ocornut/imgui/releases/tag/v1.89.4>
-  • macOS: fix stuck keys when undocking while a key is down
-  • macOS: follow the "Control+left-click emulates right-click" setting [t=277197]
-  • Windows: fix a regression in the OpenGL renderer causing crashes [p=2656531]
-
-  Documentation:
-  • Add a table of contents of the entire category tree
-  • Insert links for references with trailing wildcards (eg. StyleVar_*)
-
-  gfx2imgui:
-  • Add REAPER v6.75's gfx.getchar second return value
-  • Implement (partial) blit rotation
-  • More compatibility improvements and performance optimizations
+  • Add a button to restore default settings in the preferences page
+  • Don't give focus to the first setting when opening the preferences page [t=277729]
+  • Enable docking by default (ConfigFlags_DockingEnable) and expose a user setting
+  • Fix 1-frame flicker after uploading a new texture
+  • Fix a use-after-free when calling an EEL function after an assertion failure
+  • Fix crashes when removing/uploading textures every frame [p=2663379]
+  • Fix name conflict between the ImGui_Image type and function in the C++ header
+  • Revert "disable ConfigVar_InputTrickleEventQueue by default" [p=2664743]
+  • Update to dear imgui v1.89.5 <https://github.com/ocornut/imgui/releases/tag/v1.89.5>
 
   API changes:
-  • Add 'callback' parameter to InputText* and SetNextWindowSizeConstraints
-  • Add a boolean return value to BeginTooltip
-  • Add ConfigVar_DebugBeginReturnValue{Once,Loop}
-  • Add CreateFunctionFromEEL and Function_*
-  • Add InputTextFlags_Callback{Always,CharFilter,Completion,Edit,History}
-  • Renamed {Push,Pop}AllowKeyboardFocus to {Push,Pop}TabStop
+  • Move the C++ API functions to a ImGui namespace
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path


### PR DESCRIPTION
• Add a button to restore default settings in the preferences page
• Don't give focus to the first setting when opening the preferences page [t=277729]
• Enable docking by default (ConfigFlags_DockingEnable) and expose a user setting
• Fix 1-frame flicker after uploading a new texture
• Fix a use-after-free when calling an EEL function after an assertion failure
• Fix crashes when removing/uploading textures every frame [p=2663379]
• Fix name conflict between the ImGui_Image type and function in the C++ header
• Revert "disable ConfigVar_InputTrickleEventQueue by default" [p=2664743]
• Update to dear imgui v1.89.5 <https://github.com/ocornut/imgui/releases/tag/v1.89.5>

API changes:
• Move the C++ API functions to a ImGui namespace