### PR TITLE
Release ReaBlink: Ableton Link REAPER plug-in extension v0.4.6

### DIFF
--- a/API/ak5k_ReaBlink.ext
+++ b/API/ak5k_ReaBlink.ext
@@ -1,9 +1,7 @@
 @description ReaBlink: Ableton Link REAPER plug-in extension
 @author ak5k
-@version 0.4.5
-@changelog
-  Update to Ableton Link 3.0.6
-  Transport stopping related crash fix in Puppet mode
+@version 0.4.6
+@changelog Restored release build compatibility with older Windows versions.
 @provides
   [win64] reaper_reablink-x64.dll https://github.com/ak5k/reablink/releases/download/v$version/$path
   [script main] ReaBlink_Monitor.lua https://github.com/ak5k/reablink/releases/download/v$version/$path


### PR DESCRIPTION
Restored release build compatibility with older Windows versions.