### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.8.7.3

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,9 +1,14 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.8.7.2
+@version 0.8.7.3
 @changelog
-  • Fix a crash when windows are closed out of ownership order while a mouse button is down
-  • macOS: fix the x86_64 release binary not containing FreeType2 since 0.8.7 [p=2694907]
+  • Report stored size when opening a docked window [p=2700189]
+  • macOS and Windows: fix a memory leak and potential crash when the renderer fails to initialize
+  • macOS: fix a crash when pressing mouse buttons higher than 5
+  • macOS: fix a memory leak and a potential crash in the Metal renderer when images are incorrectly re-created every frame while a window is occluded [p=2698614]
+  • macOS: fix mouse events not reaching REAPER after opening a native menu while a mouse button is down then pressing another button
+  • macOS: release mouse capture on window focus changes [p=2695756]
+  • macOS: send a single right-click event when handling the "Control+left-click emulates right-click" setting
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path


### PR DESCRIPTION
• Report stored size when opening a docked window [p=2700189]
• macOS and Windows: fix a memory leak and potential crash when the renderer fails to initialize
• macOS: fix a crash when pressing mouse buttons higher than 5
• macOS: fix a memory leak and a potential crash in the Metal renderer when images are incorrectly re-created every frame while a window is occluded [p=2698614]
• macOS: fix mouse events not reaching REAPER after opening a native menu while a mouse button is down then pressing another button
• macOS: release mouse capture on window focus changes [p=2695756]
• macOS: send a single right-click event when handling the "Control+left-click emulates right-click" setting