### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.8.7.5

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,7 +1,15 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.8.7.4
-@changelog • Fix a crash when undocking via the context menu since 0.8.7.3
+@version 0.8.7.5
+@changelog
+  • Fix compatibility of file drag and drop with dear imgui v1.89.4
+  • Focus new docked windows when they are the only tab in the docker [p=2724239]
+  • Windows: fix detection of the "multimonitor aware" HiDPI mode on Windows 8.1 [p=2724812]
+  • Windows: fix windows not staying in place after moving under certain monitor scales [p=2724640]
+
+  gfx2imgui:
+  • Fix replacing images after (re)initializing gfx
+  • Harden gradrect to gracefully handle bogus Infinity/NaN delta arguments
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path


### PR DESCRIPTION
• Fix compatibility of file drag and drop with dear imgui v1.89.4
• Focus new docked windows when they are the only tab in the docker [p=2724239]
• Windows: fix detection of the "multimonitor aware" HiDPI mode on Windows 8.1 [p=2724812]
• Windows: fix windows not staying in place after moving under certain monitor scales [p=2724640]

gfx2imgui:
• Fix replacing images after (re)initializing gfx
• Harden gradrect to gracefully handle bogus Infinity/NaN delta arguments