### PR TITLE
Release ReaSolotus: REAPER Solo bus extension v0.1.7

### DIFF
--- a/Control Surfaces/ak5k_ReaSolotus REAPER Solo bus extension.ext
+++ b/Control Surfaces/ak5k_ReaSolotus REAPER Solo bus extension.ext
@@ -1,11 +1,12 @@
 @description ReaSolotus: REAPER Solo bus extension
 @author ak5k
-@version 0.1.6
+@version 0.1.7
+@changelog Mix and Solo busses no longer reset their positions between sessions.
 @provides
-  [linux-aarch64] reaper_reasolotus-aarch64.so https://github.com/ak5k/reasolotus/releases/download/v$version/reaper_reasolotus-aarch64.so
-  [darwin-arm64] reaper_reasolotus-arm64.dylib https://github.com/ak5k/reasolotus/releases/download/v$version/reaper_reasolotus-arm64.dylib
-  [win64] reaper_reasolotus-x64.dll https://github.com/ak5k/reasolotus/releases/download/v$version/reaper_reasolotus-x64.dll
-  [darwin64] reaper_reasolotus-x86_64.dylib https://github.com/ak5k/reasolotus/releases/download/v$version/reaper_reasolotus-x86_64.dylib
-  [linux64] reaper_reasolotus-x86_64.so https://github.com/ak5k/reasolotus/releases/download/v$version/reaper_reasolotus-x86_64.so
+  [linux-aarch64] reaper_reasolotus-aarch64.so https://github.com/ak5k/reasolotus/releases/download/v$version/$path
+  [darwin-arm64] reaper_reasolotus-arm64.dylib https://github.com/ak5k/reasolotus/releases/download/v$version/$path
+  [win64] reaper_reasolotus-x64.dll https://github.com/ak5k/reasolotus/releases/download/v$version/$path
+  [darwin64] reaper_reasolotus-x86_64.dylib https://github.com/ak5k/reasolotus/releases/download/v$version/$path
+  [linux64] reaper_reasolotus-x86_64.so https://github.com/ak5k/reasolotus/releases/download/v$version/$path
 @about Solo bus extension to improve live mixing experience with REAPER.
 


### PR DESCRIPTION
Mix and Solo busses no longer reset their positions between sessions.