### PR TITLE
Release ReaBlink: Ableton Link REAPER plug-in extension v0.5.4

### DIFF
--- a/API/ak5k_ReaBlink.ext
+++ b/API/ak5k_ReaBlink.ext
@@ -1,7 +1,7 @@
 @description ReaBlink: Ableton Link REAPER plug-in extension
 @author ak5k
-@version 0.5.3
-@changelog Improved compatibility with older REAPER versions
+@version 0.5.4
+@changelog fix dummy pre-roll regions clean-up
 @provides
   [win64] reaper_reablink-x64.dll https://github.com/ak5k/reablink/releases/download/$version/$path
   [script main] ReaBlink_Monitor.lua https://github.com/ak5k/reablink/releases/download/$version/$path


### PR DESCRIPTION
fix dummy pre-roll regions clean-up