### PR TITLE
Release ReaSolotus: REAPER Solo bus extension v0.2.0

### DIFF
--- a/Control Surfaces/ak5k_ReaSolotus REAPER Solo bus extension.ext
+++ b/Control Surfaces/ak5k_ReaSolotus REAPER Solo bus extension.ext
@@ -1,7 +1,7 @@
 @description ReaSolotus: REAPER Solo bus extension
 @author ak5k
-@version 0.1.8
-@changelog improved send handling
+@version 0.2.0
+@changelog New separate action called "ReaSolotus Init" to initialized project. Projects will have to be manually initialized. Displays error message, if ReaSolotus is enabled, but project is not initialized.
 @provides
   [linux-aarch64] reaper_reasolotus-aarch64.so https://github.com/ak5k/reasolotus/releases/download/$version/$path
   [darwin-arm64] reaper_reasolotus-arm64.dylib https://github.com/ak5k/reasolotus/releases/download/$version/$path


### PR DESCRIPTION
New separate action called "ReaSolotus Init" to initialized project. Projects will have to be manually initialized. Displays error message, if ReaSolotus is enabled, but project is not initialized.