### PR TITLE
Release ReaImGui: ReaScript binding for Dear ImGui v0.9.3.3

### DIFF
--- a/API/reaper_imgui.ext
+++ b/API/reaper_imgui.ext
@@ -1,10 +1,24 @@
 @description ReaImGui: ReaScript binding for Dear ImGui
 @author cfillion
-@version 0.9.3.2
+@version 0.9.3.3
 @changelog
-  • Fix a crash when saving screensets after more than one context shared an ID
-  • Select better font fallbacks in the HTML documentation
-  • Linux: fix a crash when opening a window on the same frame images got garbage-collected
+  • Accurately detect when script execution is suspended (REAPER v7.28+ only)
+  • Fix default flags in Demo > Widgets > Text Input > Multi-line
+  • Fix empty lines in imgui_defs.lua due to empty section help text
+  • Fix gaining logical focus when the OS window gets it from a window outside the context
+  • Fix omitting ColorPick4's ref_col parameter
+  • Fix splash screen detection being off by one frame
+  • Limit user window sizes to 8192px per axis to avoid crashes
+  • macOS: report hit-testing transparency to SWELL's WindowFromPoint
+  • Windows: fix Alt key input while holding down a mouse button when "Allow keyboard commands when mouse-editing" is disabled
+
+  gfx2imgui:
+  • Accept passing a nil and other non-string names to gfx.init
+  • Fix gfx.getchar returning a nil second value when closing
+  • Fix unattached font fallback nearest lookup
+  • Implement inverted text effect approximation
+  • Repair rectangle rotation
+  • Support uppercase font flag bytes
 @provides
   [darwin32] reaper_imgui-i386.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path
   [darwin64] reaper_imgui-x86_64.dylib https://github.com/cfillion/reaimgui/releases/download/v$version/$path


### PR DESCRIPTION
• Accurately detect when script execution is suspended (REAPER v7.28+ only)
• Fix default flags in Demo > Widgets > Text Input > Multi-line
• Fix empty lines in imgui_defs.lua due to empty section help text
• Fix gaining logical focus when the OS window gets it from a window outside the context
• Fix omitting ColorPick4's ref_col parameter
• Fix splash screen detection being off by one frame
• Limit user window sizes to 8192px per axis to avoid crashes
• macOS: report hit-testing transparency to SWELL's WindowFromPoint
• Windows: fix Alt key input while holding down a mouse button when "Allow keyboard commands when mouse-editing" is disabled

gfx2imgui:
• Accept passing a nil and other non-string names to gfx.init
• Fix gfx.getchar returning a nil second value when closing
• Fix unattached font fallback nearest lookup
• Implement inverted text effect approximation
• Repair rectangle rotation
• Support uppercase font flag bytes