### PR TITLE
Release SWS/S&M extension v2.14.0.5-beta

### DIFF
--- a/Extensions/reaper-oss_SWS.ext
+++ b/Extensions/reaper-oss_SWS.ext
@@ -1,149 +1,139 @@
 @description SWS/S&M extension
-@version 2.14.0.4-beta
+@author reaper-oss
+@version 2.14.0.5-beta
 @changelog
   Actions:
-  • Fix multi-selection in "Xenakios/SWS: Choose files for random insert" on Linux and macOS [p=2839888]
-  • Fix the red ruler getting stuck when disabling while recording
-  • Set the red ruler to yellow when recording is paused
-
-  Auto color:
-  • Repair setting the gradient end color on Windows [t=295534]
+  • Fix a crash in "SWS: Reset item rate, preserving length, clear 'preserve pitch'" when a selected item contains an empty take (issue 1939)
 
   Cycle actions:
-  • Fix running cycle actions from the editor's "Main (alt recording)" section [p=2809773]
-  • Deprecate the "Main (alt recording)" section in the Cycle Action editor
+  • Add support for REAPER v7.40's new Crossfade Editor section
 
-  MIDI editor:
-  • Account for HiDPI scaling [#1916]
-  • Clamp MIDI note velocity to 1 in Finger actions, API and when applying grooves [t=298312]
+  Hit detection:
+  • Fix Y offset in hit detection of envelope points and segments [#954]
+  • Implement hit detection of envelope points within automation items [#922]
 
-  Miscellaneous:
-  • Protect against recursive symbolic links when scanning directories [p=2813993]
+  List view: (issue 1947)
+  • Fix incorrect width when enabling columns and more than one is hidden
+  • Fix position of inserted columns ignoring preceding hidden ones
+  • Preserve custom order when adding or removing columns
 
   Notes:
-  • Don't scroll to the top when refreshing and the text is identical [#1700]
-  • Tolerate UTF-8 Byte Order Mark when importing SRT files (issue 695, issue 1928)
+  • Clear cached previous text when closing the window [#1942]
 
-  ReaScript API:
-  • Repair BR_GetMouseCursorContext over envelopes lanes set to "Project default behavior outside of automation items" [#1908]
-
-  Region playlist:
-  • Fix scrolling to the next region instead of the current one after activating [#1919]
-@author reaper-oss
-@links
+  MIDI Editor:
+  • Repair regression caused by the MIDI Editor HiDPI fix on Windows and macOS [p=2858128]
+@provides
+  [darwin-arm64] reaper_sws-arm64.dylib https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [darwin32] reaper_sws-i386.dylib https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [darwin64] reaper_sws-x86_64.dylib https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [linux-aarch64] reaper_sws-aarch64.so https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [linux-armv7l] reaper_sws-armv7l.so https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [linux32] reaper_sws-i686.so https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [linux64] reaper_sws-x86_64.so https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [win32] reaper_sws-x86.dll https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [win64] reaper_sws-x64.dll https://github.com/reaper-oss/sws/releases/download/v$version/$path
+  [script darwin-arm64] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
+  [script darwin64] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
+  [script linux-aarch64] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
+  [script linux64] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
+  [script win64] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
+  [script darwin32] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python32.py
+  [script linux-armv7l] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python32.py
+  [script linux32] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python32.py
+  [script win32] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python32.py
+  [data] Grooves/16th Quantize.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/16th%20Quantize.rgt
+  [data] Grooves/ASR10 16'th Subz 2 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/ASR10%2016'th%20Subz%202%20bar.rgt
+  [data] Grooves/ASR10 16'th triplet Subz 2 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/ASR10%2016'th%20triplet%20Subz%202%20bar.rgt
+  [data] Grooves/ASR10 32'nd Subz 2 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/ASR10%2032'nd%20Subz%202%20bar.rgt
+  [data] Grooves/ASR10 32'nd triplet Subz 2 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/ASR10%2032'nd%20triplet%20Subz%202%20bar.rgt
+  [data] Grooves/ASR10 8'th Subz 2 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/ASR10%208'th%20Subz%202%20bar.rgt
+  [data] Grooves/ASR10 8'th triplet Subz 2 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/ASR10%208'th%20triplet%20Subz%202%20bar.rgt
+  [data] Grooves/DX_16_ 50% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_16_%2050%25%20swing.rgt
+  [data] Grooves/DX_16_ 54% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_16_%2054%25%20swing.rgt
+  [data] Grooves/DX_16_ 58% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_16_%2058%25%20swing.rgt
+  [data] Grooves/DX_16_ 62% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_16_%2062%25%20swing.rgt
+  [data] Grooves/DX_16_ 66% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_16_%2066%25%20swing.rgt
+  [data] Grooves/DX_16_ 70% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_16_%2070%25%20swing.rgt
+  [data] Grooves/DX_32_ 50% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_32_%2050%25%20swing.rgt
+  [data] Grooves/DX_32_ 66% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_32_%2066%25%20swing.rgt
+  [data] Grooves/DX_32_ 83% swing.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/DX_32_%2083%25%20swing.rgt
+  [data] Grooves/Korg DDD-1-16 50%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2050%25.rgt
+  [data] Grooves/Korg DDD-1-16 54%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2054%25.rgt
+  [data] Grooves/Korg DDD-1-16 58%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2058%25.rgt
+  [data] Grooves/Korg DDD-1-16 63%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2063%25.rgt
+  [data] Grooves/Korg DDD-1-16 67%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2067%25.rgt
+  [data] Grooves/Korg DDD-1-16 71%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2071%25.rgt
+  [data] Grooves/Korg DDD-1-16 75%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2075%25.rgt
+  [data] Grooves/Korg DDD-1-16 79%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2079%25.rgt
+  [data] Grooves/Korg DDD-1-16 83%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2083%25.rgt
+  [data] Grooves/Korg DDD-1-16 88%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16%2088%25.rgt
+  [data] Grooves/Korg DDD-1-16T%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-16T%25.rgt
+  [data] Grooves/Korg DDD-1-8T%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/Korg%20DDD-1-8T%25.rgt
+  [data] Grooves/Logic_16A.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_16B.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_16C.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_16D.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_16E.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_16F.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_8A.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_8B.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_8C.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_8D.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_8E.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/Logic_8F.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
+  [data] Grooves/MPC 16'th Triplet Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2016'th%20Triplet%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 32'nd Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2032'nd%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 32'nd Triplet Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2032'nd%20Triplet%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 50% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2050%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 51% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2051%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 52% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2052%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 53% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2053%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 54% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2054%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 55% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2055%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 56% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2056%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 57% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2057%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 58% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2058%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 59% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2059%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 60% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2060%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 61% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2061%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 62% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2062%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 63% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2063%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 64% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2064%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 65% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2065%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 66% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2066%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 67% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2067%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 68% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2068%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 69% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2069%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 70% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2070%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 71% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2071%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 72% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2072%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 73% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2073%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 74% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2074%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 75% Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%2075%25%20Subz%204%20bar.rgt
+  [data] Grooves/MPC 8'th Triplet Subz 4 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/MPC%208'th%20Triplet%20Subz%204%20bar.rgt
+  [data] Grooves/SP1200_50%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_50%25.rgt
+  [data] Grooves/SP1200_50%_16T.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_50%25_16T.rgt
+  [data] Grooves/SP1200_50%_32_2bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_50%25_32_2bar.rgt
+  [data] Grooves/SP1200_50%_8T.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_50%25_8T.rgt
+  [data] Grooves/SP1200_54%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_54%25.rgt
+  [data] Grooves/SP1200_54%_16T.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_54%25_16T.rgt
+  [data] Grooves/SP1200_54%_8T.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_54%25_8T.rgt
+  [data] Grooves/SP1200_58%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_58%25.rgt
+  [data] Grooves/SP1200_63%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_63%25.rgt
+  [data] Grooves/SP1200_67%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_67%25.rgt
+  [data] Grooves/SP1200_71%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/SP1200_71%25.rgt
+  [data] Grooves/energyXT_50%.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/Grooves/energyXT_50%25.rgt
+@link
   Website https://www.sws-extension.org/
   GitHub repository https://github.com/reaper-oss/sws
   Forum thread https://forum.cockos.com/showthread.php?t=29640
 @donation
   cfillion https://reapack.com/donate
-  nofish   https://www.paypal.me/nofish
+  nofish https://www.paypal.me/nofish
 @about
   # SWS/S&M extension
 
   The SWS/S&M extension is a collection of features that seamlessly integrate into REAPER, the Digital Audio Workstation (DAW) software by Cockos, Inc.
 
   It is a collaborative and open source project.
-@provides
-  [darwin-arm64 ] reaper_sws-arm64.dylib  https://github.com/reaper-oss/sws/releases/download/v$version/$path
-  [darwin32     ] reaper_sws-i386.dylib   https://github.com/reaper-oss/sws/releases/download/v$version/$path
-  [darwin64     ] reaper_sws-x86_64.dylib https://github.com/reaper-oss/sws/releases/download/v$version/$path
-  [linux-aarch64] reaper_sws-aarch64.so   https://github.com/reaper-oss/sws/releases/download/v$version/$path
-  [linux-armv7l ] reaper_sws-armv7l.so    https://github.com/reaper-oss/sws/releases/download/v$version/$path
-  [linux32      ] reaper_sws-i686.so      https://github.com/reaper-oss/sws/releases/download/v$version/$path
-  [linux64      ] reaper_sws-x86_64.so    https://github.com/reaper-oss/sws/releases/download/v$version/$path
-  [win32        ] reaper_sws-x86.dll      https://github.com/reaper-oss/sws/releases/download/v$version/$path
-  [win64        ] reaper_sws-x64.dll      https://github.com/reaper-oss/sws/releases/download/v$version/$path
 
-  [script darwin-arm64 ] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
-  [script darwin64     ] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
-  [script linux-aarch64] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
-  [script linux64      ] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
-  [script win64        ] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python64.py
-
-  [script darwin32     ] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python32.py
-  [script linux-armv7l ] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python32.py
-  [script linux32      ] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python32.py
-  [script win32        ] ../API/sws.py https://github.com/reaper-oss/sws/releases/download/v$version/sws_python32.py
-
-  [data] Grooves/16th Quantize.rgt                  https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/ASR10 16'th Subz 2 bar.rgt         https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/ASR10 16'th triplet Subz 2 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/ASR10 32'nd Subz 2 bar.rgt         https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/ASR10 32'nd triplet Subz 2 bar.rgt https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/ASR10 8'th Subz 2 bar.rgt          https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/ASR10 8'th triplet Subz 2 bar.rgt  https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_16_ 50% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_16_ 54% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_16_ 58% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_16_ 62% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_16_ 66% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_16_ 70% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_32_ 50% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_32_ 66% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/DX_32_ 83% swing.rgt               https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 50%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 54%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 58%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 63%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 67%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 71%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 75%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 79%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 83%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16 88%.rgt              https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-16T%.rgt                https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Korg DDD-1-8T%.rgt                 https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_16A.rgt                      https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_16B.rgt                      https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_16C.rgt                      https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_16D.rgt                      https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_16E.rgt                      https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_16F.rgt                      https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_8A.rgt                       https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_8B.rgt                       https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_8C.rgt                       https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_8D.rgt                       https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_8E.rgt                       https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/Logic_8F.rgt                       https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 16'th Triplet Subz 4 bar.rgt   https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 32'nd Subz 4 bar.rgt           https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 32'nd Triplet Subz 4 bar.rgt   https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 50% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 51% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 52% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 53% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 54% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 55% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 56% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 57% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 58% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 59% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 60% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 61% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 62% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 63% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 64% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 65% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 66% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 67% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 68% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 69% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 70% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 71% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 72% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 73% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 74% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 75% Subz 4 bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/MPC 8'th Triplet Subz 4 bar.rgt    https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_50%.rgt                     https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_50%_16T.rgt                 https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_50%_32_2bar.rgt             https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_50%_8T.rgt                  https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_54%.rgt                     https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_54%_16T.rgt                 https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_54%_8T.rgt                  https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_58%.rgt                     https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_63%.rgt                     https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_67%.rgt                     https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/SP1200_71%.rgt                     https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path
-  [data] Grooves/energyXT_50%.rgt                   https://github.com/reaper-oss/sws/raw/v$version/FingersExtras/$path

--- a/Extensions/reaper-oss_SWS.ext
+++ b/Extensions/reaper-oss_SWS.ext
@@ -12,7 +12,7 @@
   • Fix Y offset in hit detection of envelope points and segments [#954]
   • Implement hit detection of envelope points within automation items [#922]
 
-  List view: (issue 1947)
+  List view: [#1947]
   • Fix incorrect width when enabling columns and more than one is hidden
   • Fix position of inserted columns ignoring preceding hidden ones
   • Preserve custom order when adding or removing columns


### PR DESCRIPTION
Actions:
• Fix a crash in "SWS: Reset item rate, preserving length, clear 'preserve pitch'" when a selected item contains an empty take (issue 1939)

Cycle actions:
• Add support for REAPER v7.40's new Crossfade Editor section

Hit detection:
• Fix Y offset in hit detection of envelope points and segments [#954]
• Implement hit detection of envelope points within automation items [#922]

List view: (issue 1947)
• Fix incorrect width when enabling columns and more than one is hidden
• Fix position of inserted columns ignoring preceding hidden ones
• Preserve custom order when adding or removing columns

Notes:
• Clear cached previous text when closing the window [#1942]

MIDI Editor:
• Repair regression caused by the MIDI Editor HiDPI fix on Windows and macOS [p=2858128]